### PR TITLE
feat: agregar endpoint para envio de informacion de producto

### DIFF
--- a/src/controllers/message.controller.js
+++ b/src/controllers/message.controller.js
@@ -593,3 +593,47 @@ export async function sendMessageReject(req, res) {
     });
   }
 }
+
+export async function sendProductInfo(req, res) {
+  try {
+    const { nombreProducto, descripcion, correo, phone, imageData } = req.body;
+
+    // Validaciones adicionales
+    if (!nombreProducto || !descripcion || !correo || !phone || !imageData) {
+      return res.status(400).json({
+        success: false,
+        message: "Faltan campos requeridos",
+        required: ["nombreProducto", "descripcion", "correo", "phone", "imageData"],
+      });
+    }
+
+    // Validar formato del teléfono
+    const cleanPhone = phone.replace(/\D/g, '');
+    if (cleanPhone.length < 10 || cleanPhone.length > 15) {
+      return res.status(400).json({
+        success: false,
+        message: "El número de teléfono debe tener entre 10 y 15 dígitos",
+      });
+    }
+
+    const result = await whatsappService.sendProductInfo({
+      nombreProducto,
+      descripcion,
+      correo,
+      phone,
+      imageData,
+    });
+
+    res.json({
+      success: true,
+      ...result,
+    });
+  } catch (error) {
+    console.error("Error en sendProductInfo:", error);
+    res.status(500).json({
+      success: false,
+      message: error.message,
+      timestamp: new Date().toISOString(),
+    });
+  }
+}

--- a/src/controllers/message.controller.js
+++ b/src/controllers/message.controller.js
@@ -596,14 +596,14 @@ export async function sendMessageReject(req, res) {
 
 export async function sendProductInfo(req, res) {
   try {
-    const { nombreProducto, descripcion, correo, phone, imageData } = req.body;
+    const { productName, description, email, phone, imageData } = req.body;
 
     // Validaciones adicionales
-    if (!nombreProducto || !descripcion || !correo || !phone || !imageData) {
+    if (!productName || !description || !email || !phone || !imageData) {
       return res.status(400).json({
         success: false,
         message: "Faltan campos requeridos",
-        required: ["nombreProducto", "descripcion", "correo", "phone", "imageData"],
+        required: ["productName", "description", "email", "phone", "imageData"],
       });
     }
 
@@ -617,9 +617,9 @@ export async function sendProductInfo(req, res) {
     }
 
     const result = await whatsappService.sendProductInfo({
-      nombreProducto,
-      descripcion,
-      correo,
+      productName,
+      description,
+      email,
       phone,
       imageData,
     });

--- a/src/routes/message.routes.js
+++ b/src/routes/message.routes.js
@@ -12,13 +12,15 @@ import {
   getReconnectionStatus,
   sendMessageWithImage,
   sendMessageAccept,
-  sendMessageReject
+  sendMessageReject,
+  sendProductInfo
 } from '../controllers/message.controller.js';
 import { 
   validateSendMessage, 
   validateSendImage, 
   validateSendMessageAccept, 
-  validateSendMessageReject 
+  validateSendMessageReject,
+  validateSendProductInfo
 } from '../validators/message.validator.js';
 import { authenticateJWT, authorizeRole } from '../middlewares/auth.middleware.js';
 import { Router } from 'express';
@@ -29,6 +31,7 @@ router.post('/send-message', authenticateJWT, authorizeRole('admin'), validateSe
 router.post('/send-message-accept', validateSendMessageAccept, sendMessageAccept);
 router.post('/send-message-reject', validateSendMessageReject, sendMessageReject);
 router.get('/sent-messages', authenticateJWT, authorizeRole('admin'), getSentMessages);
+router.post('/send-product-info', validateSendProductInfo, sendProductInfo);
 router.get('/qr-code', authenticateJWT, authorizeRole('admin'), getQrCode);
 router.post('/send-image', validateSendImage, sendMessageWithImage);
 router.get('/status', authenticateJWT, getStatus);

--- a/src/services/whatsapp.service.js
+++ b/src/services/whatsapp.service.js
@@ -802,7 +802,7 @@ export default {
     }
   },
 
-  async sendProductInfo({ nombreProducto, descripcion, correo, phone, imageData }) {
+  async sendProductInfo({ productName, description, email, phone, imageData }) {
     if (!connectionState.socket?.user) {
       throw new Error('No conectado a WhatsApp. Por favor, escanea el código QR primero.');
     }
@@ -820,9 +820,9 @@ export default {
     }
 
     const messageText = getProductDetailsTemplate({
-      nombreProducto,
-      descripcion,
-      correo,
+      productName,
+      description,
+      email,
     });
 
     if (!messageText) {
@@ -847,9 +847,9 @@ export default {
     try {
       const captionText = messageText || 'Imagen enviada';
       logger.info('Enviando mensaje con imagen WhatsApp', {
-        nombreProducto,
-        descripcion,
-        correo,
+        productName,
+        description,
+        email,
         phone: formattedPhone,
         imageSize: imageBuffer.length,
         captionLength: captionText.length

--- a/src/services/whatsapp.service.js
+++ b/src/services/whatsapp.service.js
@@ -1,6 +1,6 @@
 import { makeWASocket, useMultiFileAuthState, makeCacheableSignalKeyStore } from '@whiskeysockets/baileys';
 import QRCode from 'qrcode';
-import { getTemplate } from '../templates.js';
+import { getTemplate, getProductDetailsTemplate } from '../templates.js';
 import logger from '../utils/logger.js';
 import { emitQrStatusUpdate } from '../app.js';
 import { getWhatsAppConfig } from '../config/whatsapp.config.js';
@@ -727,6 +727,129 @@ export default {
     try {
       const captionText = caption || 'Imagen enviada';
       logger.info('Enviando mensaje con imagen WhatsApp', {
+        phone: formattedPhone,
+        imageSize: imageBuffer.length,
+        captionLength: captionText.length
+      });
+
+      // Preparar mensaje con imagen
+      const messageOptions = {
+        image: imageBuffer,
+        caption: captionText,
+        jpegThumbnail: null,
+      };
+
+      const result = await connectionState.socket.sendMessage(formattedPhone, messageOptions);
+
+      logger.info('Mensaje enviado exitosamente', {
+        phone: formattedPhone,
+        messageId: result.key.id,
+        timestamp: new Date().toISOString()
+      });
+
+      const sentMessage = {
+        phone: formattedPhone,
+        messageId: result.key.id,
+        sentAt: new Date().toISOString(),
+        messagePreview: captionText.substring(0, 100) + (captionText.length > 100 ? '...' : ''),
+        type: 'image',
+        imageSize: imageBuffer.length,
+        status: 'sent'
+      };
+
+      connectionState.sentMessages.push(sentMessage);
+
+      const config = getWhatsAppConfig();
+      if (connectionState.sentMessages.length > (config.messages?.maxHistorySize || 100)) {
+        connectionState.sentMessages = connectionState.sentMessages.slice(-(config.messages?.maxHistorySize || 100));
+      }
+
+      return {
+        success: true,
+        messageId: result.key.id,
+        phone: formattedPhone,
+        sentAt: new Date().toISOString(),
+        messagePreview: captionText.substring(0, 100) + (captionText.length > 100 ? '...' : ''),
+        type: 'image',
+        imageSize: imageBuffer.length
+      };
+
+    } catch (error) {
+      logger.error('Error enviando mensaje WhatsApp', {
+        phone: formattedPhone,
+        error: error.message,
+        stack: error.stack
+      });
+
+      if (error.message.includes('disconnected')) {
+        await cleanupConnection();
+        throw new Error('Conexión perdida con WhatsApp. Por favor, escanea el código QR nuevamente.');
+      }
+
+      if (error.message.includes('not-authorized')) {
+        throw new Error('No tienes autorización para enviar mensajes a este número.');
+      }
+
+      if (error.message.includes('forbidden')) {
+        throw new Error('No se puede enviar mensajes a este número. Verifica que el número sea válido.');
+      }
+
+      if (error.message.includes('rate limit')) {
+        throw new Error('Límite de mensajes alcanzado. Espera un momento antes de enviar más mensajes.');
+      }
+
+      throw new Error(`Error al enviar mensaje: ${error.message}`);
+    }
+  },
+
+  async sendProductInfo({ nombreProducto, descripcion, correo, phone, imageData }) {
+    if (!connectionState.socket?.user) {
+      throw new Error('No conectado a WhatsApp. Por favor, escanea el código QR primero.');
+    }
+
+    const cleanPhone = phone.replace(/\D/g, '');
+    if (cleanPhone.length < 10 || cleanPhone.length > 15) {
+      throw new Error('El número de teléfono debe tener entre 10 y 15 dígitos');
+    }
+
+    const formattedPhone = `${cleanPhone}@s.whatsapp.net`;
+
+    // Validar datos de imagen
+    if (!imageData) {
+      throw new Error('Los datos de la imagen son requeridos');
+    }
+
+    const messageText = getProductDetailsTemplate({
+      nombreProducto,
+      descripcion,
+      correo,
+    });
+
+    if (!messageText) {
+      throw new Error('Plantilla de mensaje no válida');
+    }
+
+    let imageBuffer;
+    try {
+      // Remover prefijo data:image si existe
+      const base64Data = imageData.replace(/^data:image\/[a-z]+;base64,/, '');
+      imageBuffer = Buffer.from(base64Data, 'base64');
+
+      // Validar tamaño de imagen (máximo 16MB para WhatsApp)
+      const maxSize = 16 * 1024 * 1024; // 16MB
+      if (imageBuffer.length > maxSize) {
+        throw new Error('La imagen es demasiado grande. El tamaño máximo es 16MB');
+      }
+    } catch (error) {
+      throw new Error('Formato de imagen base64 inválido');
+    }
+
+    try {
+      const captionText = messageText || 'Imagen enviada';
+      logger.info('Enviando mensaje con imagen WhatsApp', {
+        nombreProducto,
+        descripcion,
+        correo,
         phone: formattedPhone,
         imageSize: imageBuffer.length,
         captionLength: captionText.length

--- a/src/templates.js
+++ b/src/templates.js
@@ -117,31 +117,31 @@ ${comentario ? `💬 Comentario del administrador:
 
 export function getProductDetailsTemplate(params = {}) {
   const {
-    nombreProducto = '',
-    descripcion = '',
-    correo = '',
+    productName = '',
+    description = '',
+    email = '',
   } = params;
 
-  return `📢 **Bienvenido a Yuntas Publicidad** 📢
+  return `📢 Bienvenido a Yuntas Publicidad 📢
 
-    Gracias por su interés en nuestros productos. A continuación, le proporcionamos los detalles del producto que ha consultado:
+Gracias por su interés en nuestros productos. A continuación, le proporcionamos los detalles del producto que ha consultado:
 
-    📝 **Producto Consultado:**
-      • **Nombre del Producto:** ${nombreProducto}  
-      • **Descripción:** ${descripcion}  
+📝 Producto Consultado:
+    • Nombre del Producto: ${productName}  
+    • Descripción: ${description}  
 
-    📅 **Fecha y Hora de Consulta:**  
-      • **Fecha:** ${new Date().toLocaleDateString('es-ES')}  
-      • **Hora:** ${new Date().toLocaleTimeString('es-ES')}  
+📅 Fecha y Hora de Consulta:  
+    • Fecha: ${new Date().toLocaleDateString('es-ES')}  
+    • Hora: ${new Date().toLocaleTimeString('es-ES')}  
 
-    📧 **Información Adicional:**  
-    Le informamos que en breve recibirá un correo electrónico a ${correo} con más detalles sobre el producto consultado. Le recomendamos revisar su bandeja de entrada.
+📧 Información Adicional:  
+Le informamos que en breve recibirá un correo electrónico a ${email} con más detalles sobre el producto consultado. Le recomendamos revisar su bandeja de entrada.
 
-    Si tiene alguna otra consulta o desea más información, no dude en contactarnos.
+Si tiene alguna otra consulta o desea más información, no dude en contactarnos.
 
-    ¡Gracias por elegirnos!
+¡Gracias por elegirnos!
 
-    Atentamente,  
-    **Yuntas Publicidad**  
+Atentamente,  
+Yuntas Publicidad  
   `;
 }

--- a/src/templates.js
+++ b/src/templates.js
@@ -114,3 +114,34 @@ ${comentario ? `💬 Comentario del administrador:
 
 ¡Estamos aquí para ayudarte a resolverlo! 🤝`;
 }
+
+export function getProductDetailsTemplate(params = {}) {
+  const {
+    nombreProducto = '',
+    descripcion = '',
+    correo = '',
+  } = params;
+
+  return `📢 **Bienvenido a Yuntas Publicidad** 📢
+
+    Gracias por su interés en nuestros productos. A continuación, le proporcionamos los detalles del producto que ha consultado:
+
+    📝 **Producto Consultado:**
+      • **Nombre del Producto:** ${nombreProducto}  
+      • **Descripción:** ${descripcion}  
+
+    📅 **Fecha y Hora de Consulta:**  
+      • **Fecha:** ${new Date().toLocaleDateString('es-ES')}  
+      • **Hora:** ${new Date().toLocaleTimeString('es-ES')}  
+
+    📧 **Información Adicional:**  
+    Le informamos que en breve recibirá un correo electrónico a ${correo} con más detalles sobre el producto consultado. Le recomendamos revisar su bandeja de entrada.
+
+    Si tiene alguna otra consulta o desea más información, no dude en contactarnos.
+
+    ¡Gracias por elegirnos!
+
+    Atentamente,  
+    **Yuntas Publicidad**  
+  `;
+}

--- a/src/validators/message.validator.js
+++ b/src/validators/message.validator.js
@@ -183,3 +183,64 @@ export const validateSendMessageReject = [
     next();
   }
 ];
+
+export const validateSendProductInfo = [
+  // Validación de teléfono
+  body('telefono')
+    .isString()
+    .notEmpty()
+    .withMessage('El número de teléfono es requerido')
+    .matches(/^[\d\s\-\+\(\)]+$/)
+    .withMessage('El número de teléfono debe contener solo dígitos, espacios, guiones, paréntesis y signo +'),
+
+  // Validación de correo
+  body('correo')
+    .isString()
+    .notEmpty()
+    .withMessage('El correo electrónico es requerido')
+    .isEmail()
+    .withMessage('El correo electrónico debe tener un formato válido'),
+
+  // Validación de imagen
+  body('imageData')
+    .isString()
+    .notEmpty()
+    .withMessage('Los datos de la imagen son requeridos')
+    .custom((value) => {
+      // Validar que sea base64 válido
+      if (!value.startsWith('data:image/')) {
+        throw new Error('Los datos de la imagen deben estar en formato base64 con prefijo data:image/');
+      }
+
+      // Validar que tenga el formato correcto
+      const base64Regex = /^data:image\/[a-z]+;base64,/;
+      if (!base64Regex.test(value)) {
+        throw new Error('Formato de imagen base64 inválido');
+      }
+
+      // Validar que el contenido base64 no esté vacío
+      const base64Data = value.replace(/^data:image\/[a-z]+;base64,/, '');
+      if (!base64Data || base64Data.length === 0) {
+        throw new Error('El contenido de la imagen no puede estar vacío');
+      }
+
+      return true;
+    }),
+
+  // Validación personalizada para verificar el formato de la imagen
+  (req, res, next) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({
+        success: false,
+        message: 'Errores de validación',
+        errors: errors.array().map((error) => ({
+          field: error.path,
+          message: error.msg,
+          value: error.value,
+        })),
+      });
+    }
+    next();
+  }
+];

--- a/src/validators/message.validator.js
+++ b/src/validators/message.validator.js
@@ -186,7 +186,7 @@ export const validateSendMessageReject = [
 
 export const validateSendProductInfo = [
   // Validación de teléfono
-  body('telefono')
+  body('phone')
     .isString()
     .notEmpty()
     .withMessage('El número de teléfono es requerido')
@@ -194,7 +194,7 @@ export const validateSendProductInfo = [
     .withMessage('El número de teléfono debe contener solo dígitos, espacios, guiones, paréntesis y signo +'),
 
   // Validación de correo
-  body('correo')
+  body('email')
     .isString()
     .notEmpty()
     .withMessage('El correo electrónico es requerido')


### PR DESCRIPTION
En el ```message.route.js``` declaramos el nuevo endpoint

```Express.js
router.post('/send-product-info', validateSendProductInfo, sendProductInfo);
```

Los campos que requiere son los siguientes

```Express.js
const { productName, description, email, phone, imageData } = req.body;
```

Y se tiene el siguiente response

```json
{
    "success": true,
    "messageId": "3EB07F215608E9BDC2E6F5",
    "phone": "51951011604@s.whatsapp.net",
    "sentAt": "2025-10-04T14:02:19.085Z",
    "messagePreview": "Hola",
    "type": "image",
    "imageSize": 22816
}
```
cabe aclarar que las imágenes deben tener la siguiente estructura con ```data:image/``` como prefijo, esto ya se controla en el front  de whatsapp para ver como se envia, pero cuando se usa el endpoint ```/send-product-info``` se debe verificar que cumpla el formato

<img width="1225" height="216" alt="image" src="https://github.com/user-attachments/assets/16e374ac-5197-44fa-99b4-689450181269" />
